### PR TITLE
📝 Add GitHub repository link

### DIFF
--- a/src/app/(mdx)/(top)/page.mdx
+++ b/src/app/(mdx)/(top)/page.mdx
@@ -1,3 +1,5 @@
+- [nextjs-park-ui-on-vercel] (This GitHub repository)
+
 ## Features
 
 - [Next.js] v14 (App Router)
@@ -39,6 +41,7 @@ https://github.com/chakra-ui/panda/tree/main/sandbox/next-js-app
 Panda CSS - Website  
 https://github.com/chakra-ui/panda/tree/main/website
 
+[nextjs-park-ui-on-vercel]: https://github.com/cieloazul310/nextjs-park-ui-on-vercel
 [Next.js]: https://nextjs.org/
 [Park UI]: https://park-ui.com/
 [Ark UI]: https://ark-ui.com/


### PR DESCRIPTION
グーグルの検索結果に表示されるので、念のため GitHub へのリンクが有ると良いと優しいかなと思い追加しました。

表示結果のイメージ | 検索結果
-|-
<kbd> ![image](https://github.com/user-attachments/assets/1ee2f634-c8fb-4be4-8b47-8cc4d871480f) | <kbd> ![image](https://github.com/user-attachments/assets/a51f2de1-a898-4586-8e73-6e8ba11c7d02)</kbd> <br> (言語を英語にしたり地域をアメリカ合衆国に設定して検索した結果は [Qiit の記事](https://qiita.com/cieloazul310/items/72a46fecdfceea6265b4)は表示されませんでした)

別な対応案として、  
[Material UI](https://mui.com/material-ui/) の様に Header・Navbar にリンクが有っても良いと思いました。

<kbd> ![image](https://github.com/user-attachments/assets/5338ebeb-7df2-4be8-a5ea-99d4e2fe4b71)

お時間ありましたら、対応などご検討いただければ幸いです。